### PR TITLE
Fix bug with first argument being parsed twice into two different variables

### DIFF
--- a/examples-c/addon.c
+++ b/examples-c/addon.c
@@ -28,7 +28,7 @@ napi_value add_numbers(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_get_value_int32(env, argv[0], &a));
 
   int b;
-  NAPI_CALL(env, napi_get_value_int32(env, argv[0], &b));
+  NAPI_CALL(env, napi_get_value_int32(env, argv[1], &b));
 
   napi_value result;
   NAPI_CALL(env, napi_create_int32(env, a + b, &result));


### PR DESCRIPTION
During the [talk](https://www.youtube.com/watch?v=UzTPBy2acio) we saw weird behavior when two numbers ware not correctly added.
It caused by a typo where we store the same first value into both a and b variables.